### PR TITLE
Add opacity to <img> tags

### DIFF
--- a/content.css
+++ b/content.css
@@ -2,3 +2,7 @@
   background-color: black !important;
   color: #777 !important;
 }
+
+.mata-friendly, .mata-friendly img {
+  opacity: 0.7 !important;
+}


### PR DESCRIPTION
Sometimes when reading in night mode there might be very bright images and it's not good for eyes.
This fix should change opacity of all img tags to 0.7 making them less bright and therefore more pleasant for your eyes.
